### PR TITLE
Update cypress config

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,6 +2,7 @@ const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   e2e: {
+    baseUrl: "http://localhost:3000",
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },


### PR DESCRIPTION
Added the local host as a base url in Cypress config so we only have to put something like "/" or "/my-council-account/" in the test to get to page