### PR TITLE
Add create password page

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,6 +2,7 @@ const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   e2e: {
+    baseUrl: "http://localhost:3000",
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress/e2e/create-password.cy.js
+++ b/cypress/e2e/create-password.cy.js
@@ -49,18 +49,44 @@ describe("create password page", () => {
     );
   });
 
-  // it("shows error if password doesn't contain at least one number and special character", () => {
-  //   cy.get('[data-cy="password-input"]').type("password");
-  //   cy.get('[data-cy="continue-button"]').contains("Continue").click();
-  //   cy.contains(
-  //     "Enter a password with at least one number and one special character"
-  //   );
-  //   cy.get('[data-cy="event-name-error"]').should(
-  //     "have.css",
-  //     "color",
-  //     "rgb(212, 53, 28)"
-  //   );
-  // });
+  it("shows error if password doesn't contain at least one number and special character", () => {
+    cy.get('[data-cy="password-input"]').type("password");
+    cy.get('[data-cy="continue-button"]').contains("Continue").click();
+    cy.contains(
+      "Enter a password with at least one number and one special character"
+    );
+    cy.get('[data-cy="event-name-error"]').should(
+      "have.css",
+      "color",
+      "rgb(212, 53, 28)"
+    );
+  });
+
+  it("shows error if password doesn't contain at least one number", () => {
+    cy.get('[data-cy="password-input"]').type("password@");
+    cy.get('[data-cy="continue-button"]').contains("Continue").click();
+    cy.contains(
+      "Enter a password with at least one number and one special character"
+    );
+    cy.get('[data-cy="event-name-error"]').should(
+      "have.css",
+      "color",
+      "rgb(212, 53, 28)"
+    );
+  });
+
+  it("shows error if password doesn't contain at least one special character", () => {
+    cy.get('[data-cy="password-input"]').type("password1");
+    cy.get('[data-cy="continue-button"]').contains("Continue").click();
+    cy.contains(
+      "Enter a password with at least one number and one special character"
+    );
+    cy.get('[data-cy="event-name-error"]').should(
+      "have.css",
+      "color",
+      "rgb(212, 53, 28)"
+    );
+  });
   // it("shows an error when both passwords don't match", () => {
   //   cy.get('[data-cy="password-input"]').type("Type!1day");
   //   cy.get('[data-cy="confirm-password-input"]').type("Type!tttt");

--- a/cypress/e2e/create-password.cy.js
+++ b/cypress/e2e/create-password.cy.js
@@ -41,7 +41,13 @@ describe("create password page", () => {
   it("show an error if the password is less than 8 characters", () => {
     cy.get('[data-cy="password-input"]').type("pass");
     cy.get('[data-cy="continue-button"]').contains("Continue").click();
-    cy.contains("Enter a password with a minimum of 8 characters");
+    cy.get('[data-cy="password-error"]').contains(
+      "Password must be 8 characters or more"
+    );
+    cy.get('[data-cy="password-error-summary"]').contains("There is a problem");
+    cy.get('[data-cy="password-error-summary"]').contains(
+      "Password must be 8 characters or more"
+    );
     cy.get('[data-cy="password-error"]').should(
       "have.css",
       "color",
@@ -53,6 +59,11 @@ describe("create password page", () => {
       "rgb(212, 53, 28)"
     );
     cy.get('[data-cy="confirm-password-input"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="password-error-summary"]').should(
       "have.css",
       "border-color",
       "rgb(212, 53, 28)"
@@ -67,7 +78,11 @@ describe("create password page", () => {
   it("shows error if password doesn't contain at least one number and special character", () => {
     cy.get('[data-cy="password-input"]').type("password");
     cy.get('[data-cy="continue-button"]').contains("Continue").click();
-    cy.contains(
+    cy.get('[data-cy="password-error"]').contains(
+      "Enter a password with at least one number and one special character"
+    );
+    cy.get('[data-cy="password-error-summary"]').contains("There is a problem");
+    cy.get('[data-cy="password-error-summary"]').contains(
       "Enter a password with at least one number and one special character"
     );
     cy.get('[data-cy="password-error"]').should(
@@ -81,6 +96,11 @@ describe("create password page", () => {
       "rgb(212, 53, 28)"
     );
     cy.get('[data-cy="confirm-password-input"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="password-error-summary"]').should(
       "have.css",
       "border-color",
       "rgb(212, 53, 28)"
@@ -95,7 +115,11 @@ describe("create password page", () => {
   it("shows error if password doesn't contain at least one number", () => {
     cy.get('[data-cy="password-input"]').type("password@");
     cy.get('[data-cy="continue-button"]').contains("Continue").click();
-    cy.contains(
+    cy.get('[data-cy="password-error"]').contains(
+      "Enter a password with at least one number and one special character"
+    );
+    cy.get('[data-cy="password-error-summary"]').contains("There is a problem");
+    cy.get('[data-cy="password-error-summary"]').contains(
       "Enter a password with at least one number and one special character"
     );
     cy.get('[data-cy="password-error"]').should(
@@ -109,6 +133,11 @@ describe("create password page", () => {
       "rgb(212, 53, 28)"
     );
     cy.get('[data-cy="confirm-password-input"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="password-error-summary"]').should(
       "have.css",
       "border-color",
       "rgb(212, 53, 28)"
@@ -123,7 +152,11 @@ describe("create password page", () => {
   it("shows error if password doesn't contain at least one special character", () => {
     cy.get('[data-cy="password-input"]').type("password1");
     cy.get('[data-cy="continue-button"]').contains("Continue").click();
-    cy.contains(
+    cy.get('[data-cy="password-error"]').contains(
+      "Enter a password with at least one number and one special character"
+    );
+    cy.get('[data-cy="password-error-summary"]').contains("There is a problem");
+    cy.get('[data-cy="password-error-summary"]').contains(
       "Enter a password with at least one number and one special character"
     );
     cy.get('[data-cy="password-error"]').should(
@@ -137,6 +170,11 @@ describe("create password page", () => {
       "rgb(212, 53, 28)"
     );
     cy.get('[data-cy="confirm-password-input"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="password-error-summary"]').should(
       "have.css",
       "border-color",
       "rgb(212, 53, 28)"
@@ -152,7 +190,13 @@ describe("create password page", () => {
     cy.get('[data-cy="password-input"]').type("Type!1day");
     cy.get('[data-cy="confirm-password-input"]').type("Type!t2tt");
     cy.get('[data-cy="continue-button"]').contains("Continue").click();
-    cy.contains("Both passwords should match");
+    cy.get('[data-cy="password-error"]').contains(
+      "Both passwords should match"
+    );
+    cy.get('[data-cy="password-error-summary"]').contains("There is a problem");
+    cy.get('[data-cy="password-error-summary"]').contains(
+      "Both passwords should match"
+    );
     cy.get('[data-cy="password-error"]').should(
       "have.css",
       "color",
@@ -168,6 +212,11 @@ describe("create password page", () => {
       "border-color",
       "rgb(212, 53, 28)"
     );
+    cy.get('[data-cy="password-error-summary"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
     cy.get('[data-cy="password-input"]').should(
       "have.attr",
       "aria-describedby",
@@ -179,6 +228,27 @@ describe("create password page", () => {
     cy.get('[data-cy="password-input"]').type("Type!1day");
     cy.get('[data-cy="confirm-password-input"]').type("Type!1day");
     cy.get('[data-cy="continue-button"]').contains("Continue").click();
-    cy.url().should("eq", "http://localhost:3000/create-password/#");
+    cy.url().should("eq", "http://localhost:3000/document-list");
+  });
+
+  it("shows an error when password isn't accepted but accepts after next attempt meets requirements", () => {
+    cy.get('[data-cy="password-input"]').type("Type!1day");
+    cy.get('[data-cy="confirm-password-input"]').type("Type!t2tt");
+    cy.get('[data-cy="continue-button"]').contains("Continue").click();
+    cy.get('[data-cy="password-error"]').contains(
+      "Both passwords should match"
+    );
+    cy.get('[data-cy="password-error-summary"]').contains("There is a problem");
+    cy.get('[data-cy="password-error-summary"]').contains(
+      "Both passwords should match"
+    );
+    cy.get('[data-cy="password-error-summary"]').contains(
+      "Both passwords should match"
+    );
+
+    cy.get('[data-cy="password-input"]').clear().type("Type!1day");
+    cy.get('[data-cy="confirm-password-input"]').clear().type("Type!1day");
+    cy.get('[data-cy="continue-button"]').contains("Continue").click();
+    cy.url().should("eq", "http://localhost:3000/document-list");
   });
 });

--- a/cypress/e2e/create-password.cy.js
+++ b/cypress/e2e/create-password.cy.js
@@ -1,54 +1,85 @@
 describe("create password page", () => {
-  it("loads the page", () => {
+  beforeEach(() => {
     cy.visit("/create-password");
   });
 
   it("shows the correct page title", () => {
-    cy.visit("/create-password");
-    cy.get("h1").contains("Create a password for your account");
+    cy.get('[data-cy="section-heading-h1"]').contains(
+      "Create a password for your account"
+    );
   });
 
   it("can go back to the previous page", () => {
-    cy.visit("/create-password");
-    cy.get("a").contains("Back").click();
+    cy.get('[data-cy="back-link"]').click();
     cy.url().should("eq", "http://localhost:3000/create-password/#");
   });
 
   it("shows the password length requirements", () => {
-    cy.visit("/create-password");
     cy.contains("must contain 8 digits");
   });
 
   it("shows the password input field and value", () => {
-    cy.visit("/create-password");
-    cy.get("#password")
-      .type("password test")
-      .should("have.value", "password test");
+    cy.get('[data-cy="password-input"]')
+      .type("passwordtest")
+      .should("have.value", "passwordtest");
   });
 
   it("shows the label for the confirm password input", () => {
-    cy.visit("/create-password");
     cy.contains("Confirm password");
   });
 
   it("shows the password input field and value", () => {
-    cy.visit("/create-password");
-    cy.get("#confirm-password")
-      .type("confirm password test")
-      .should("have.value", "confirm password test");
+    cy.get('[data-cy="confirm-password-input"]')
+      .type("confirmpasswordtest")
+      .should("have.value", "confirmpasswordtest");
   });
 
   it("shows the continue button", () => {
-    cy.visit("/create-password");
-    cy.get("button").contains("Continue");
+    cy.get('[data-cy="continue-button"]').contains("Continue");
   });
+
+  it("show an error if the password is less than 8 characters", () => {
+    cy.get('[data-cy="password-input"]').type("pass");
+    cy.get('[data-cy="continue-button"]').contains("Continue").click();
+    cy.contains("Enter a password with a minimum of 8 characters");
+    cy.get('[data-cy="event-name-error"]').should(
+      "have.css",
+      "color",
+      "rgb(212, 53, 28)"
+    );
+  });
+
+  // it("shows error if password doesn't contain at least one number and special character", () => {
+  //   cy.get('[data-cy="password-input"]').type("password");
+  //   cy.get('[data-cy="continue-button"]').contains("Continue").click();
+  //   cy.contains(
+  //     "Enter a password with at least one number and one special character"
+  //   );
+  //   cy.get('[data-cy="event-name-error"]').should(
+  //     "have.css",
+  //     "color",
+  //     "rgb(212, 53, 28)"
+  //   );
+  // });
+  // it("shows an error when both passwords don't match", () => {
+  //   cy.get('[data-cy="password-input"]').type("Type!1day");
+  //   cy.get('[data-cy="confirm-password-input"]').type("Type!tttt");
+  //   cy.get('[data-cy="continue-button"]').contains("Continue").click();
+  //   cy.get('[data-cy="no-match-error"]').contains(
+  //     "Both passwords should match"
+  //   );
+  // });
 });
 
 //tests to write
-//first password field and value
+
 //Validate it matches requirement
+// order of validation
+//length of password
+//type of characters required
+// passwords match
 //requirement: 8 digits, at least one number and one special character
-//second password field and value
+
 //hide both passwords
 //both values match
 //error if doesn't match

--- a/cypress/e2e/create-password.cy.js
+++ b/cypress/e2e/create-password.cy.js
@@ -2,4 +2,8 @@ describe("create password page", () => {
   it("loads the page", () => {
     cy.visit("/create-password");
   });
+  it("shows the correct page title", () => {
+    cy.visit("/create-password");
+    cy.get("h1").should("have.text", "Create a password for your account");
+  });
 });

--- a/cypress/e2e/create-password.cy.js
+++ b/cypress/e2e/create-password.cy.js
@@ -87,13 +87,24 @@ describe("create password page", () => {
       "rgb(212, 53, 28)"
     );
   });
-  // it("shows an error when both passwords don't match", () => {
+
+  it("shows an error when both passwords don't match", () => {
+    cy.get('[data-cy="password-input"]').type("Type!1day");
+    cy.get('[data-cy="confirm-password-input"]').type("Type!t2tt");
+    cy.get('[data-cy="continue-button"]').contains("Continue").click();
+    cy.contains("Both passwords should match");
+    cy.get('[data-cy="event-name-error"]').should(
+      "have.css",
+      "color",
+      "rgb(212, 53, 28)"
+    );
+  });
+
+  // it("goes to the next page when the password matches the requirements", () => {
   //   cy.get('[data-cy="password-input"]').type("Type!1day");
-  //   cy.get('[data-cy="confirm-password-input"]').type("Type!tttt");
+  //   cy.get('[data-cy="confirm-password-input"]').type("Type!1day");
   //   cy.get('[data-cy="continue-button"]').contains("Continue").click();
-  //   cy.get('[data-cy="no-match-error"]').contains(
-  //     "Both passwords should match"
-  //   );
+  //   cy.url().should("eq", "http://localhost:3000/create-password/#");
   // });
 });
 

--- a/cypress/e2e/create-password.cy.js
+++ b/cypress/e2e/create-password.cy.js
@@ -329,4 +329,41 @@ describe("create password page", () => {
     cy.get('[data-cy="continue-button"]').contains("Continue").click();
     cy.url().should("eq", "http://localhost:3000/document-list");
   });
+
+  context("enter is pressed on keyboard", () => {
+    it("shows an error when password is only typed on first input", () => {
+      cy.get('[data-cy="password-input"]').clear().type("Type{enter}");
+      cy.get('[data-cy="password-error"]').contains(
+        "Password must be 8 characters or more"
+      );
+      cy.get('[data-cy="password-error"]').should(
+        "have.css",
+        "color",
+        "rgb(212, 53, 28)"
+      );
+    });
+
+    it("shows an error when password typed on both inputs but incorrect requirements", () => {
+      cy.get('[data-cy="password-input"]').clear().type("Typesadas2^");
+      cy.get('[data-cy="confirm-password-input"]')
+        .clear()
+        .type("Type!1day{enter}");
+      cy.get('[data-cy="password-error"]').contains(
+        "Both passwords should match"
+      );
+      cy.get('[data-cy="password-error"]').should(
+        "have.css",
+        "color",
+        "rgb(212, 53, 28)"
+      );
+    });
+
+    it("moves to next page when pressing enter after matching passwords are typed", () => {
+      cy.get('[data-cy="password-input"]').clear().type("Type!1day");
+      cy.get('[data-cy="confirm-password-input"]')
+        .clear()
+        .type("Type!1day{enter}");
+      cy.url().should("eq", "http://localhost:3000/document-list");
+    });
+  });
 });

--- a/cypress/e2e/create-password.cy.js
+++ b/cypress/e2e/create-password.cy.js
@@ -2,18 +2,46 @@ describe("create password page", () => {
   it("loads the page", () => {
     cy.visit("/create-password");
   });
+
   it("shows the correct page title", () => {
     cy.visit("/create-password");
-    cy.get("h1").should("have.text", "Create a password for your account");
+    cy.get("h1").contains("Create a password for your account");
   });
+
+  it("can go back to the previous page", () => {
+    cy.visit("/create-password");
+    cy.get("a").contains("Back").click();
+    cy.url().should("eq", "http://localhost:3000/create-password/#");
+  });
+
   it("shows the password length requirements", () => {
     cy.visit("/create-password");
     cy.contains("must contain 8 digits");
   });
-  //   it("shows the password input field", () => {
-  //     cy.visit("/create-password");
-  //     cy.get("input").expect().exist();
-  //   });
+
+  it("shows the password input field and value", () => {
+    cy.visit("/create-password");
+    cy.get("#password")
+      .type("password test")
+      .should("have.value", "password test");
+  });
+
+  it("shows the label for the confirm password input", () => {
+    cy.visit("/create-password");
+    cy.contains("Confirm password");
+  });
+
+  it("shows the password input field and value", () => {
+    cy.visit("/create-password");
+    cy.get("#confirm-password")
+      .type("confirm password test")
+      .should("have.value", "confirm password test");
+  });
+
+  it("shows the continue button", () => {
+    cy.visit("/create-password");
+    cy.get("button").contains("Continue");
+  });
 });
 
 //tests to write
@@ -21,6 +49,16 @@ describe("create password page", () => {
 //Validate it matches requirement
 //requirement: 8 digits, at least one number and one special character
 //second password field and value
+//hide both passwords
 //both values match
 //error if doesn't match
 //continue button and it goes to next page
+
+//Full test order
+// go to page
+// type password
+// validate password
+// show error if not valid
+// confirm password
+// show error if passwords don't match
+// click continue and be taken to next page

--- a/cypress/e2e/create-password.cy.js
+++ b/cypress/e2e/create-password.cy.js
@@ -18,210 +18,296 @@ describe("create password page", () => {
     cy.contains("must contain 8 digits");
   });
 
-  it("shows the password input field and value", () => {
-    cy.get('[data-cy="password-input"]')
-      .type("passwordtest")
-      .should("have.value", "passwordtest");
+  context("password input", () => {
+    it("shows the password input field", () => {
+      cy.get('[data-cy="password-input"]')
+        .type("passwordtest")
+        .should("have.value", "passwordtest");
+    });
   });
 
-  it("shows the label for the confirm password input", () => {
-    cy.contains("Confirm password");
-  });
+  context("confirm password input", () => {
+    it("shows the label for the confirm password input", () => {
+      cy.contains("Confirm password");
+    });
 
-  it("shows the password input field and value", () => {
-    cy.get('[data-cy="confirm-password-input"]')
-      .type("confirmpasswordtest")
-      .should("have.value", "confirmpasswordtest");
+    it("shows the confirm password input field", () => {
+      cy.get('[data-cy="confirm-password-input"]')
+        .type("confirmpasswordtest")
+        .should("have.value", "confirmpasswordtest");
+    });
   });
 
   it("shows the continue button", () => {
     cy.get('[data-cy="continue-button"]').contains("Continue");
   });
 
-  it("show an error if the password is less than 8 characters", () => {
-    cy.get('[data-cy="password-input"]').type("pass");
-    cy.get('[data-cy="continue-button"]').contains("Continue").click();
-    cy.get('[data-cy="password-error"]').contains(
-      "Password must be 8 characters or more"
-    );
-    cy.get('[data-cy="password-error-summary"]').contains("There is a problem");
-    cy.get('[data-cy="password-error-summary"]').contains(
-      "Password must be 8 characters or more"
-    );
-    cy.get('[data-cy="password-error"]').should(
-      "have.css",
-      "color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-input"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="confirm-password-input"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-error-summary"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-input"]').should(
-      "have.attr",
-      "aria-describedby",
-      "password-hint password-error"
-    );
+  context("password is less than 8 characters", () => {
+    beforeEach(() => {
+      cy.get('[data-cy="password-input"]').type("pass");
+      cy.get('[data-cy="continue-button"]').contains("Continue").click();
+    });
+
+    it("shows an error message ", () => {
+      cy.get('[data-cy="password-error"]').contains(
+        "Password must be 8 characters or more"
+      );
+      cy.get('[data-cy="password-error"]').should(
+        "have.css",
+        "color",
+        "rgb(212, 53, 28)"
+      );
+    });
+
+    it("shows an error summary ", () => {
+      cy.get('[data-cy="password-error-summary"]').contains(
+        "There is a problem"
+      );
+      cy.get('[data-cy="password-error-summary"]').contains(
+        "Password must be 8 characters or more"
+      );
+      cy.get('[data-cy="password-error-summary"]').should(
+        "have.css",
+        "border-color",
+        "rgb(212, 53, 28)"
+      );
+    });
+
+    it("changes the border colour of the input fields", () => {
+      cy.get('[data-cy="password-input"]').should(
+        "have.css",
+        "border-color",
+        "rgb(212, 53, 28)"
+      );
+      cy.get('[data-cy="confirm-password-input"]').should(
+        "have.css",
+        "border-color",
+        "rgb(212, 53, 28)"
+      );
+    });
+
+    it("adds an aria describe by attribute", () => {
+      cy.get('[data-cy="password-input"]').should(
+        "have.attr",
+        "aria-describedby",
+        "password-hint password-error"
+      );
+    });
   });
 
-  it("shows error if password doesn't contain at least one number and special character", () => {
-    cy.get('[data-cy="password-input"]').type("password");
-    cy.get('[data-cy="continue-button"]').contains("Continue").click();
-    cy.get('[data-cy="password-error"]').contains(
-      "Enter a password with at least one number and one special character"
-    );
-    cy.get('[data-cy="password-error-summary"]').contains("There is a problem");
-    cy.get('[data-cy="password-error-summary"]').contains(
-      "Enter a password with at least one number and one special character"
-    );
-    cy.get('[data-cy="password-error"]').should(
-      "have.css",
-      "color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-input"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="confirm-password-input"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-error-summary"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-input"]').should(
-      "have.attr",
-      "aria-describedby",
-      "password-hint password-error"
-    );
+  context(
+    "password doesn't contain at least one number and one special character",
+    () => {
+      beforeEach(() => {
+        cy.get('[data-cy="password-input"]').type("password");
+        cy.get('[data-cy="continue-button"]').contains("Continue").click();
+      });
+
+      it("shows an error message", () => {
+        cy.get('[data-cy="password-error"]').contains(
+          "Enter a password with at least one number and one special character"
+        );
+        cy.get('[data-cy="password-error"]').should(
+          "have.css",
+          "color",
+          "rgb(212, 53, 28)"
+        );
+      });
+
+      it("shows an error summary", () => {
+        cy.get('[data-cy="password-error-summary"]').contains(
+          "There is a problem"
+        );
+        cy.get('[data-cy="password-error-summary"]').contains(
+          "Enter a password with at least one number and one special character"
+        );
+        cy.get('[data-cy="password-error-summary"]').should(
+          "have.css",
+          "border-color",
+          "rgb(212, 53, 28)"
+        );
+      });
+
+      it("changes the border colour of the input fields", () => {
+        cy.get('[data-cy="password-input"]').should(
+          "have.css",
+          "border-color",
+          "rgb(212, 53, 28)"
+        );
+        cy.get('[data-cy="confirm-password-input"]').should(
+          "have.css",
+          "border-color",
+          "rgb(212, 53, 28)"
+        );
+      });
+      it("adds an aria describe by attribute", () => {
+        cy.get('[data-cy="password-input"]').should(
+          "have.attr",
+          "aria-describedby",
+          "password-hint password-error"
+        );
+      });
+    }
+  );
+
+  context("password doesn't contain at least one number", () => {
+    beforeEach(() => {
+      cy.get('[data-cy="password-input"]').type("password@");
+      cy.get('[data-cy="continue-button"]').contains("Continue").click();
+    });
+
+    it("shows an error message", () => {
+      cy.get('[data-cy="password-error"]').contains(
+        "Enter a password with at least one number and one special character"
+      );
+      cy.get('[data-cy="password-error"]').should(
+        "have.css",
+        "color",
+        "rgb(212, 53, 28)"
+      );
+    });
+
+    it("shows an error summary", () => {
+      cy.get('[data-cy="password-error-summary"]').contains(
+        "There is a problem"
+      );
+      cy.get('[data-cy="password-error-summary"]').contains(
+        "Enter a password with at least one number and one special character"
+      );
+      cy.get('[data-cy="password-error-summary"]').should(
+        "have.css",
+        "border-color",
+        "rgb(212, 53, 28)"
+      );
+    });
+
+    it("changes the border colour of the input fields", () => {
+      cy.get('[data-cy="password-input"]').should(
+        "have.css",
+        "border-color",
+        "rgb(212, 53, 28)"
+      );
+      cy.get('[data-cy="confirm-password-input"]').should(
+        "have.css",
+        "border-color",
+        "rgb(212, 53, 28)"
+      );
+    });
+
+    it("adds an aria describe by attribute", () => {
+      cy.get('[data-cy="password-input"]').should(
+        "have.attr",
+        "aria-describedby",
+        "password-hint password-error"
+      );
+    });
   });
 
-  it("shows error if password doesn't contain at least one number", () => {
-    cy.get('[data-cy="password-input"]').type("password@");
-    cy.get('[data-cy="continue-button"]').contains("Continue").click();
-    cy.get('[data-cy="password-error"]').contains(
-      "Enter a password with at least one number and one special character"
-    );
-    cy.get('[data-cy="password-error-summary"]').contains("There is a problem");
-    cy.get('[data-cy="password-error-summary"]').contains(
-      "Enter a password with at least one number and one special character"
-    );
-    cy.get('[data-cy="password-error"]').should(
-      "have.css",
-      "color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-input"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="confirm-password-input"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-error-summary"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-input"]').should(
-      "have.attr",
-      "aria-describedby",
-      "password-hint password-error"
-    );
+  context("password doesn't contain at least one special character", () => {
+    beforeEach(() => {
+      cy.get('[data-cy="password-input"]').type("password1");
+      cy.get('[data-cy="continue-button"]').contains("Continue").click();
+    });
+
+    it("shows an error message", () => {
+      cy.get('[data-cy="password-error"]').contains(
+        "Enter a password with at least one number and one special character"
+      );
+      cy.get('[data-cy="password-error"]').should(
+        "have.css",
+        "color",
+        "rgb(212, 53, 28)"
+      );
+    });
+
+    it("shows an error summary", () => {
+      cy.get('[data-cy="password-error-summary"]').contains(
+        "There is a problem"
+      );
+      cy.get('[data-cy="password-error-summary"]').contains(
+        "Enter a password with at least one number and one special character"
+      );
+      cy.get('[data-cy="password-error-summary"]').should(
+        "have.css",
+        "border-color",
+        "rgb(212, 53, 28)"
+      );
+    });
+
+    it("changes the border colour of the input fields", () => {
+      cy.get('[data-cy="password-input"]').should(
+        "have.css",
+        "border-color",
+        "rgb(212, 53, 28)"
+      );
+      cy.get('[data-cy="confirm-password-input"]').should(
+        "have.css",
+        "border-color",
+        "rgb(212, 53, 28)"
+      );
+    });
+
+    it("adds an aria describe by attribute", () => {
+      cy.get('[data-cy="password-input"]').should(
+        "have.attr",
+        "aria-describedby",
+        "password-hint password-error"
+      );
+    });
   });
 
-  it("shows error if password doesn't contain at least one special character", () => {
-    cy.get('[data-cy="password-input"]').type("password1");
-    cy.get('[data-cy="continue-button"]').contains("Continue").click();
-    cy.get('[data-cy="password-error"]').contains(
-      "Enter a password with at least one number and one special character"
-    );
-    cy.get('[data-cy="password-error-summary"]').contains("There is a problem");
-    cy.get('[data-cy="password-error-summary"]').contains(
-      "Enter a password with at least one number and one special character"
-    );
-    cy.get('[data-cy="password-error"]').should(
-      "have.css",
-      "color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-input"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="confirm-password-input"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-error-summary"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-input"]').should(
-      "have.attr",
-      "aria-describedby",
-      "password-hint password-error"
-    );
-  });
+  context("passwords don't match", () => {
+    beforeEach(() => {
+      cy.get('[data-cy="password-input"]').type("Type!1day");
+      cy.get('[data-cy="confirm-password-input"]').type("Type!t2tt");
+      cy.get('[data-cy="continue-button"]').contains("Continue").click();
+    });
 
-  it("shows an error when both passwords don't match", () => {
-    cy.get('[data-cy="password-input"]').type("Type!1day");
-    cy.get('[data-cy="confirm-password-input"]').type("Type!t2tt");
-    cy.get('[data-cy="continue-button"]').contains("Continue").click();
-    cy.get('[data-cy="password-error"]').contains(
-      "Both passwords should match"
-    );
-    cy.get('[data-cy="password-error-summary"]').contains("There is a problem");
-    cy.get('[data-cy="password-error-summary"]').contains(
-      "Both passwords should match"
-    );
-    cy.get('[data-cy="password-error"]').should(
-      "have.css",
-      "color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-input"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="confirm-password-input"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-error-summary"]').should(
-      "have.css",
-      "border-color",
-      "rgb(212, 53, 28)"
-    );
-    cy.get('[data-cy="password-input"]').should(
-      "have.attr",
-      "aria-describedby",
-      "password-hint password-error"
-    );
+    it("shows an error message", () => {
+      cy.get('[data-cy="password-error"]').contains(
+        "Both passwords should match"
+      );
+      cy.get('[data-cy="password-error"]').should(
+        "have.css",
+        "color",
+        "rgb(212, 53, 28)"
+      );
+    });
+
+    it("shows an error summary", () => {
+      cy.get('[data-cy="password-error-summary"]').contains(
+        "There is a problem"
+      );
+      cy.get('[data-cy="password-error-summary"]').contains(
+        "Both passwords should match"
+      );
+      cy.get('[data-cy="password-error-summary"]').should(
+        "have.css",
+        "border-color",
+        "rgb(212, 53, 28)"
+      );
+    });
+
+    it("changes the border colour of the input fields", () => {
+      cy.get('[data-cy="password-input"]').should(
+        "have.css",
+        "border-color",
+        "rgb(212, 53, 28)"
+      );
+      cy.get('[data-cy="confirm-password-input"]').should(
+        "have.css",
+        "border-color",
+        "rgb(212, 53, 28)"
+      );
+    });
+
+    it("adds an aria describe by attribute", () => {
+      cy.get('[data-cy="password-input"]').should(
+        "have.attr",
+        "aria-describedby",
+        "password-hint password-error"
+      );
+    });
   });
 
   it("goes to the next page when the password matches requirements", () => {
@@ -238,14 +324,6 @@ describe("create password page", () => {
     cy.get('[data-cy="password-error"]').contains(
       "Both passwords should match"
     );
-    cy.get('[data-cy="password-error-summary"]').contains("There is a problem");
-    cy.get('[data-cy="password-error-summary"]').contains(
-      "Both passwords should match"
-    );
-    cy.get('[data-cy="password-error-summary"]').contains(
-      "Both passwords should match"
-    );
-
     cy.get('[data-cy="password-input"]').clear().type("Type!1day");
     cy.get('[data-cy="confirm-password-input"]').clear().type("Type!1day");
     cy.get('[data-cy="continue-button"]').contains("Continue").click();

--- a/cypress/e2e/create-password.cy.js
+++ b/cypress/e2e/create-password.cy.js
@@ -1,0 +1,5 @@
+describe("create password page", () => {
+  it("loads the page", () => {
+    cy.visit("/create-password");
+  });
+});

--- a/cypress/e2e/create-password.cy.js
+++ b/cypress/e2e/create-password.cy.js
@@ -6,4 +6,21 @@ describe("create password page", () => {
     cy.visit("/create-password");
     cy.get("h1").should("have.text", "Create a password for your account");
   });
+  it("shows the password length requirements", () => {
+    cy.visit("/create-password");
+    cy.contains("must contain 8 digits");
+  });
+  //   it("shows the password input field", () => {
+  //     cy.visit("/create-password");
+  //     cy.get("input").expect().exist();
+  //   });
 });
+
+//tests to write
+//first password field and value
+//Validate it matches requirement
+//requirement: 8 digits, at least one number and one special character
+//second password field and value
+//both values match
+//error if doesn't match
+//continue button and it goes to next page

--- a/cypress/e2e/create-password.cy.js
+++ b/cypress/e2e/create-password.cy.js
@@ -11,7 +11,7 @@ describe("create password page", () => {
 
   it("can go back to the previous page", () => {
     cy.get('[data-cy="back-link"]').click();
-    cy.url().should("eq", "http://localhost:3000/create-password/#");
+    cy.url().should("eq", "http://localhost:3000/email-address");
   });
 
   it("shows the password length requirements", () => {
@@ -42,10 +42,25 @@ describe("create password page", () => {
     cy.get('[data-cy="password-input"]').type("pass");
     cy.get('[data-cy="continue-button"]').contains("Continue").click();
     cy.contains("Enter a password with a minimum of 8 characters");
-    cy.get('[data-cy="event-name-error"]').should(
+    cy.get('[data-cy="password-error"]').should(
       "have.css",
       "color",
       "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="password-input"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="confirm-password-input"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="password-input"]').should(
+      "have.attr",
+      "aria-describedby",
+      "password-hint password-error"
     );
   });
 
@@ -55,10 +70,25 @@ describe("create password page", () => {
     cy.contains(
       "Enter a password with at least one number and one special character"
     );
-    cy.get('[data-cy="event-name-error"]').should(
+    cy.get('[data-cy="password-error"]').should(
       "have.css",
       "color",
       "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="password-input"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="confirm-password-input"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="password-input"]').should(
+      "have.attr",
+      "aria-describedby",
+      "password-hint password-error"
     );
   });
 
@@ -68,10 +98,25 @@ describe("create password page", () => {
     cy.contains(
       "Enter a password with at least one number and one special character"
     );
-    cy.get('[data-cy="event-name-error"]').should(
+    cy.get('[data-cy="password-error"]').should(
       "have.css",
       "color",
       "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="password-input"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="confirm-password-input"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="password-input"]').should(
+      "have.attr",
+      "aria-describedby",
+      "password-hint password-error"
     );
   });
 
@@ -81,10 +126,25 @@ describe("create password page", () => {
     cy.contains(
       "Enter a password with at least one number and one special character"
     );
-    cy.get('[data-cy="event-name-error"]').should(
+    cy.get('[data-cy="password-error"]').should(
       "have.css",
       "color",
       "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="password-input"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="confirm-password-input"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="password-input"]').should(
+      "have.attr",
+      "aria-describedby",
+      "password-hint password-error"
     );
   });
 
@@ -93,40 +153,32 @@ describe("create password page", () => {
     cy.get('[data-cy="confirm-password-input"]').type("Type!t2tt");
     cy.get('[data-cy="continue-button"]').contains("Continue").click();
     cy.contains("Both passwords should match");
-    cy.get('[data-cy="event-name-error"]').should(
+    cy.get('[data-cy="password-error"]').should(
       "have.css",
       "color",
       "rgb(212, 53, 28)"
     );
+    cy.get('[data-cy="password-input"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="confirm-password-input"]').should(
+      "have.css",
+      "border-color",
+      "rgb(212, 53, 28)"
+    );
+    cy.get('[data-cy="password-input"]').should(
+      "have.attr",
+      "aria-describedby",
+      "password-hint password-error"
+    );
   });
 
-  // it("goes to the next page when the password matches the requirements", () => {
-  //   cy.get('[data-cy="password-input"]').type("Type!1day");
-  //   cy.get('[data-cy="confirm-password-input"]').type("Type!1day");
-  //   cy.get('[data-cy="continue-button"]').contains("Continue").click();
-  //   cy.url().should("eq", "http://localhost:3000/create-password/#");
-  // });
+  it("goes to the next page when the password matches requirements", () => {
+    cy.get('[data-cy="password-input"]').type("Type!1day");
+    cy.get('[data-cy="confirm-password-input"]').type("Type!1day");
+    cy.get('[data-cy="continue-button"]').contains("Continue").click();
+    cy.url().should("eq", "http://localhost:3000/create-password/#");
+  });
 });
-
-//tests to write
-
-//Validate it matches requirement
-// order of validation
-//length of password
-//type of characters required
-// passwords match
-//requirement: 8 digits, at least one number and one special character
-
-//hide both passwords
-//both values match
-//error if doesn't match
-//continue button and it goes to next page
-
-//Full test order
-// go to page
-// type password
-// validate password
-// show error if not valid
-// confirm password
-// show error if passwords don't match
-// click continue and be taken to next page

--- a/public/create-password/index.html
+++ b/public/create-password/index.html
@@ -124,6 +124,7 @@
         <a href="/email-address" class="govuk-back-link" data-cy="back-link"
           >Back</a
         >
+
         <span id="error-summary"></span>
 
         <form
@@ -135,7 +136,7 @@
           id="account-password"
         >
           <div id="password-fields">
-            <div class="govuk-form-group">
+            <div class="govuk-form-group password-form-group">
               <h1 class="govuk-label-wrapper" data-cy="section-heading-h1">
                 <label class="govuk-label govuk-label--l" for="password">
                   Create a password for your account
@@ -147,19 +148,19 @@
               </div>
               <span id="error"></span>
               <input
-                class="govuk-input govuk-input--width-20 password"
+                class="govuk-input govuk-input--width-20"
                 id="password"
                 name="password"
                 type="password"
                 data-cy="password-input"
               />
-              <br />
-              <br />
+            </div>
+            <div class="govuk-form-group confirm-password-form-group">
               <label class="govuk-label" for="confirm-password"
                 >Confirm password</label
               >
               <input
-                class="govuk-input govuk-input--width-20 confirm-password"
+                class="govuk-input govuk-input--width-20"
                 id="confirm-password"
                 name="confirm-password"
                 type="password"

--- a/public/create-password/index.html
+++ b/public/create-password/index.html
@@ -124,6 +124,7 @@
         <a href="/email-address" class="govuk-back-link" data-cy="back-link"
           >Back</a
         >
+        <span id="error-summary"></span>
 
         <form
           action="/create-password"

--- a/public/create-password/index.html
+++ b/public/create-password/index.html
@@ -45,9 +45,10 @@
     />
 
     <!--[if !IE 8]><!-->
-    <link href="/govuk-frontend/govuk/all.css" rel="stylesheet" />
+    <!-- <link href="/govuk-frontend/govuk/all.css" rel="stylesheet" /> -->
+    <link href="../stylesheet/styles.css" rel="stylesheet" />
     <!--<![endif]-->
-    <link href="/stylesheet/styles.css" rel="stylesheet" />
+
     <!--[if IE 8]>
       <link href="/govuk-frontend/all-ie8.css" rel="stylesheet" />
     <![endif]-->
@@ -120,39 +121,95 @@
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content" role="main">
-        <a href="#" class="govuk-back-link">Back</a>
+        <a href="#" class="govuk-back-link" data-cy="back-link">Back</a>
 
-        <div class="govuk-form-group">
-          <h1 class="govuk-label-wrapper">
-            <label class="govuk-label govuk-label--l" for="password">
-              Create a password for your account
-            </label>
-          </h1>
-          <p class="govuk-body-m">
-            Password must contain 8 digits, at least on number and one special
-            character
-          </p>
-          <input
-            class="govuk-input govuk-input--width-20"
-            id="password"
-            name="password"
-            type="text"
-          />
-        </div>
-        <div class="govuk-form-group">
-          <label class="govuk-label" for="confirm-password"
-            >Confirm password</label
+        <form
+          action="/create-password"
+          method="POST"
+          autocomplete="off"
+          novalidate="true"
+          spellcheck="false"
+          id="account-password"
+        >
+          <div id="password-fields">
+            <div class="govuk-form-group">
+              <h1 class="govuk-label-wrapper" data-cy="section-heading-h1">
+                <label class="govuk-label govuk-label--l" for="password">
+                  Create a password for your account
+                </label>
+              </h1>
+              <p class="govuk-body-m">
+                Password must contain 8 digits, at least one number and one
+                special character
+              </p>
+              <input
+                class="govuk-input govuk-input--width-20"
+                id="password"
+                name="password"
+                type="text"
+                data-cy="password-input"
+              />
+            </div>
+            <div class="govuk-form-group">
+              <label class="govuk-label" for="confirm-password"
+                >Confirm password</label
+              >
+              <input
+                class="govuk-input govuk-input--width-20"
+                id="confirm-password"
+                name="confirm-password"
+                type="text"
+                data-cy="confirm-password-input"
+              />
+            </div>
+          </div>
+
+          <!-- <div id="length-error-password-fields" class="no-display">
+            <div class="govuk-form-group govuk-form-group--error">
+              <h1 class="govuk-label-wrapper">
+                <label class="govuk-label govuk-label--l" for="event-name">
+                  Create a password for your account
+                </label>
+              </h1>
+              <div id="event-name-hint" class="govuk-hint">
+                Password must contain 8 digits, at least one number and one
+                special character
+              </div>
+              <p id="event-name-error" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error:</span> Enter a
+                password with a minimum of 8 characters
+              </p>
+              <input
+                class="govuk-input govuk-input--width-20 govuk-input--error"
+                id="event-name"
+                name="event-name"
+                type="text"
+                data-cy="length-error-password-input"
+                aria-describedby="event-name-hint event-name-error"
+              />
+              <br /><br />
+              <label class="govuk-label" for="confirm-password"
+                >Confirm password</label
+              >
+              <input
+                class="govuk-input govuk-input--width-20"
+                id="confirm-password"
+                name="confirm-password"
+                type="text"
+                data-cy="length-error-confirm-password-input"
+              />
+            </div>
+          </div> -->
+          <button
+            class="govuk-button"
+            data-module="govuk-button"
+            data-cy="continue-button"
+            id="continue-button"
+            type="button"
           >
-          <input
-            class="govuk-input govuk-input--width-20"
-            id="confirm-password"
-            name="confirm-password"
-            type="text"
-          />
-        </div>
-        <button class="govuk-button" data-module="govuk-button">
-          Continue
-        </button>
+            Continue
+          </button>
+        </form>
       </main>
     </div>
 
@@ -194,8 +251,8 @@
         </div>
       </div>
     </footer>
-
-    <script src="/javascripts/gov.js"></script>
+    <script src="../javascripts/create-password.js"></script>
+    <script src="../javascripts/gov.js"></script>
     <script>
       window.GOVUKFrontend.initAll();
     </script>

--- a/public/create-password/index.html
+++ b/public/create-password/index.html
@@ -121,11 +121,38 @@
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <a href="#" class="govuk-back-link">Back</a>
-        <h1 class="govuk-heading-xl">Create a password for your account</h1>
-        <p class="govuk-body-m">
-          Password must contain 8 digits, at least on number and one special
-          character
-        </p>
+
+        <div class="govuk-form-group">
+          <h1 class="govuk-label-wrapper">
+            <label class="govuk-label govuk-label--l" for="password">
+              Create a password for your account
+            </label>
+          </h1>
+          <p class="govuk-body-m">
+            Password must contain 8 digits, at least on number and one special
+            character
+          </p>
+          <input
+            class="govuk-input govuk-input--width-20"
+            id="password"
+            name="password"
+            type="text"
+          />
+        </div>
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="confirm-password"
+            >Confirm password</label
+          >
+          <input
+            class="govuk-input govuk-input--width-20"
+            id="confirm-password"
+            name="confirm-password"
+            type="text"
+          />
+        </div>
+        <button class="govuk-button" data-module="govuk-button">
+          Continue
+        </button>
       </main>
     </div>
 

--- a/public/create-password/index.html
+++ b/public/create-password/index.html
@@ -112,9 +112,9 @@
           </a>
         </div>
         <div class="govuk-header__content">
-          <a href="#" class="govuk-header__link govuk-header__service-name">
+          <span class="govuk-header__service-name">
             Birmingham City Council
-          </a>
+          </span>
         </div>
       </div>
     </header>

--- a/public/create-password/index.html
+++ b/public/create-password/index.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+  <head>
+    <meta charset="utf-8" />
+    <title>
+      GOV.UK - The best place to find government services and information
+    </title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <meta name="theme-color" content="#0b0c0c" />
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
+    <link
+      rel="shortcut icon"
+      sizes="16x16 32x32 48x48"
+      href="/assets/images/favicon.ico"
+      type="image/x-icon"
+    />
+    <link
+      rel="mask-icon"
+      href="/assets/images/govuk-mask-icon.svg"
+      color="#0b0c0c"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/assets/images/govuk-apple-touch-icon-180x180.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="167x167"
+      href="/assets/images/govuk-apple-touch-icon-167x167.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="152x152"
+      href="/assets/images/govuk-apple-touch-icon-152x152.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      href="/assets/images/govuk-apple-touch-icon.png"
+    />
+
+    <!--[if !IE 8]><!-->
+    <link href="/govuk-frontend/govuk/all.css" rel="stylesheet" />
+    <!--<![endif]-->
+    <link href="/stylesheet/styles.css" rel="stylesheet" />
+    <!--[if IE 8]>
+      <link href="/govuk-frontend/all-ie8.css" rel="stylesheet" />
+    <![endif]-->
+
+    <!--[if lt IE 9]>
+      <script src="/html5-shiv/html5shiv.js"></script>
+    <![endif]-->
+
+    <meta
+      property="og:image"
+      content="/assets/images/govuk-opengraph-image.png"
+    />
+  </head>
+
+  <body class="govuk-template__body">
+    <script>
+      document.body.className = document.body.className
+        ? document.body.className + " js-enabled"
+        : "js-enabled";
+    </script>
+
+    <a
+      href="#main-content"
+      class="govuk-skip-link"
+      data-module="govuk-skip-link"
+      >Skip to main content</a
+    >
+
+    <header class="govuk-header" role="banner" data-module="govuk-header">
+      <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo">
+          <a href="/" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <!--[if gt IE 8]><!-->
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                class="govuk-header__logotype-crown"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 132 97"
+                height="30"
+                width="36"
+              >
+                <path
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+                ></path>
+              </svg>
+              <!--<![endif]-->
+              <!--[if IE 8]>
+                <img
+                  src="/assets/images/govuk-logotype-crown.png"
+                  class="govuk-header__logotype-crown-fallback-image"
+                  width="36"
+                  height="32"
+                />
+              <![endif]-->
+              <span class="govuk-header__logotype-text"> GOV.UK </span>
+            </span>
+          </a>
+        </div>
+        <div class="govuk-header__content">
+          <a href="#" class="govuk-header__link govuk-header__service-name">
+            Birmingham City Council
+          </a>
+        </div>
+      </div>
+    </header>
+
+    <div class="govuk-width-container">
+      <main class="govuk-main-wrapper" id="main-content" role="main">
+        <h1 class="govuk-heading-xl">Default page template</h1>
+        <!-- page code goes here -->
+      </main>
+    </div>
+
+    <footer class="govuk-footer" role="contentinfo">
+      <div class="govuk-width-container">
+        <div class="govuk-footer__meta">
+          <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              class="govuk-footer__licence-logo"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 483.2 195.7"
+              height="17"
+              width="41"
+            >
+              <path
+                fill="currentColor"
+                d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+              />
+            </svg>
+            <span class="govuk-footer__licence-description">
+              All content is available under the
+              <a
+                class="govuk-footer__link"
+                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                rel="license"
+                >Open Government Licence v3.0</a
+              >, except where otherwise stated
+            </span>
+          </div>
+          <div class="govuk-footer__meta-item">
+            <a
+              class="govuk-footer__link govuk-footer__copyright-logo"
+              href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+              >© Crown copyright</a
+            >
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script src="/javascripts/gov.js"></script>
+    <script>
+      window.GOVUKFrontend.initAll();
+    </script>
+  </body>
+</html>

--- a/public/create-password/index.html
+++ b/public/create-password/index.html
@@ -120,8 +120,12 @@
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content" role="main">
+        <a href="#" class="govuk-back-link">Back</a>
         <h1 class="govuk-heading-xl">Create a password for your account</h1>
-        <!-- page code goes here -->
+        <p class="govuk-body-m">
+          Password must contain 8 digits, at least on number and one special
+          character
+        </p>
       </main>
     </div>
 

--- a/public/create-password/index.html
+++ b/public/create-password/index.html
@@ -120,7 +120,7 @@
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content" role="main">
-        <h1 class="govuk-heading-xl">Default page template</h1>
+        <h1 class="govuk-heading-xl">Create a password for your account</h1>
         <!-- page code goes here -->
       </main>
     </div>

--- a/public/create-password/index.html
+++ b/public/create-password/index.html
@@ -121,7 +121,9 @@
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content" role="main">
-        <a href="#" class="govuk-back-link" data-cy="back-link">Back</a>
+        <a href="/email-address" class="govuk-back-link" data-cy="back-link"
+          >Back</a
+        >
 
         <form
           action="/create-password"
@@ -138,68 +140,33 @@
                   Create a password for your account
                 </label>
               </h1>
-              <p class="govuk-body-m">
+              <div id="password-name-hint" class="govuk-hint">
                 Password must contain 8 digits, at least one number and one
                 special character
-              </p>
+              </div>
+              <span id="error"></span>
               <input
-                class="govuk-input govuk-input--width-20"
+                class="govuk-input govuk-input--width-20 password"
                 id="password"
                 name="password"
-                type="text"
+                type="password"
                 data-cy="password-input"
               />
-            </div>
-            <div class="govuk-form-group">
+              <br />
+              <br />
               <label class="govuk-label" for="confirm-password"
                 >Confirm password</label
               >
               <input
-                class="govuk-input govuk-input--width-20"
+                class="govuk-input govuk-input--width-20 confirm-password"
                 id="confirm-password"
                 name="confirm-password"
-                type="text"
+                type="password"
                 data-cy="confirm-password-input"
               />
             </div>
           </div>
 
-          <!-- <div id="length-error-password-fields" class="no-display">
-            <div class="govuk-form-group govuk-form-group--error">
-              <h1 class="govuk-label-wrapper">
-                <label class="govuk-label govuk-label--l" for="event-name">
-                  Create a password for your account
-                </label>
-              </h1>
-              <div id="event-name-hint" class="govuk-hint">
-                Password must contain 8 digits, at least one number and one
-                special character
-              </div>
-              <p id="event-name-error" class="govuk-error-message">
-                <span class="govuk-visually-hidden">Error:</span> Enter a
-                password with a minimum of 8 characters
-              </p>
-              <input
-                class="govuk-input govuk-input--width-20 govuk-input--error"
-                id="event-name"
-                name="event-name"
-                type="text"
-                data-cy="length-error-password-input"
-                aria-describedby="event-name-hint event-name-error"
-              />
-              <br /><br />
-              <label class="govuk-label" for="confirm-password"
-                >Confirm password</label
-              >
-              <input
-                class="govuk-input govuk-input--width-20"
-                id="confirm-password"
-                name="confirm-password"
-                type="text"
-                data-cy="length-error-confirm-password-input"
-              />
-            </div>
-          </div> -->
           <button
             class="govuk-button"
             data-module="govuk-button"

--- a/public/javascripts/create-password.js
+++ b/public/javascripts/create-password.js
@@ -7,6 +7,7 @@ const passwordFields = document.querySelector("#password-fields");
 continueEvent.addEventListener("click", checkPassword);
 
 let passwordMinimumLength = 8;
+let passwordRegex = /^(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]/;
 
 // console.log(passwordInput);
 
@@ -69,7 +70,43 @@ function checkPassword(event) {
           />
         </div>
       </div>`;
-    // removeClass(lengthErrorPasswordFields);
-    // addClass(initialPasswordFields);
+  } else if (!passwordInput.value.match(passwordRegex)) {
+    passwordFields.innerHTML = `<div id="password-fields">
+        <div class="govuk-form-group govuk-form-group--error">
+          <h1 class="govuk-label-wrapper">
+            <label class="govuk-label govuk-label--l" for="event-name">
+              Create a password for your account
+            </label>
+          </h1>
+          <div id="event-name-hint" class="govuk-hint">
+            Password must contain 8 digits, at least one number and one special
+            character
+          </div>
+          <p id="event-name-error" class="govuk-error-message" data-cy="event-name-error">
+            <span class="govuk-visually-hidden" >Error:</span> Enter a password with
+            at least one number and one special character
+          </p>
+          <input
+            class="govuk-input govuk-input--width-20 govuk-input--error"
+            id="event-name"
+            name="event-name"
+            type="text"
+            data-cy="length-error-password-input"
+            aria-describedby="event-name-hint event-name-error"
+          />
+          <br />
+          <br />
+          <label class="govuk-label" for="confirm-password">
+            Confirm password
+          </label>
+          <input
+            class="govuk-input govuk-input--width-20"
+            id="confirm-password"
+            name="confirm-password"
+            type="text"
+            data-cy="length-error-confirm-password-input"
+          />
+        </div>
+      </div>`;
   }
 }

--- a/public/javascripts/create-password.js
+++ b/public/javascripts/create-password.js
@@ -1,0 +1,75 @@
+const continueEvent = document.querySelector("#continue-button");
+const passwordFields = document.querySelector("#password-fields");
+// const lengthErrorPasswordFields = document.querySelector(
+//   "#length-error-password-fields"
+// );
+
+continueEvent.addEventListener("click", checkPassword);
+
+let passwordMinimumLength = 8;
+
+// console.log(passwordInput);
+
+// function showPasswordLengthError(password) {
+//   if (password.length < passwordMinimumLength) {
+//     console.log("nope");
+//   } else {
+//     console.log("ok");
+//   }
+// }
+
+// function removeClass(classToHide) {
+//   classToHide.classList.remove("no-display");
+// }
+
+// function addClass(classToAdd) {
+//   classToAdd.classList.add("no-display");
+// }
+
+function checkPassword(event) {
+  event.preventDefault();
+  let passwordInput = document.querySelector("#password");
+  // let confirmPasswordInput = document.querySelector("#confirm-password");
+  console.log(passwordInput.value.length);
+  if (passwordInput.value.length < passwordMinimumLength) {
+    passwordFields.innerHTML = `<div id="password-fields">
+        <div class="govuk-form-group govuk-form-group--error">
+          <h1 class="govuk-label-wrapper">
+            <label class="govuk-label govuk-label--l" for="event-name">
+              Create a password for your account
+            </label>
+          </h1>
+          <div id="event-name-hint" class="govuk-hint">
+            Password must contain 8 digits, at least one number and one special
+            character
+          </div>
+          <p id="event-name-error" class="govuk-error-message" data-cy="event-name-error">
+            <span class="govuk-visually-hidden" >Error:</span> Enter a password
+            with a minimum of 8 characters
+          </p>
+          <input
+            class="govuk-input govuk-input--width-20 govuk-input--error"
+            id="event-name"
+            name="event-name"
+            type="text"
+            data-cy="length-error-password-input"
+            aria-describedby="event-name-hint event-name-error"
+          />
+          <br />
+          <br />
+          <label class="govuk-label" for="confirm-password">
+            Confirm password
+          </label>
+          <input
+            class="govuk-input govuk-input--width-20"
+            id="confirm-password"
+            name="confirm-password"
+            type="text"
+            data-cy="length-error-confirm-password-input"
+          />
+        </div>
+      </div>`;
+    // removeClass(lengthErrorPasswordFields);
+    // addClass(initialPasswordFields);
+  }
+}

--- a/public/javascripts/create-password.js
+++ b/public/javascripts/create-password.js
@@ -4,6 +4,7 @@ const formGroup = document.querySelector(".govuk-form-group");
 const passwordInput = document.querySelector("#password");
 const confirmPasswordInput = document.querySelector("#confirm-password");
 const errorTextSection = document.querySelector("#error");
+const errorSummarySection = document.querySelector("#error-summary");
 
 continueEvent.addEventListener("click", checkPassword);
 
@@ -32,7 +33,7 @@ function showError(errorType) {
   addAriaAttribute(passwordInput, confirmPasswordInput);
 
   if (errorType === "length") {
-    errorMessage = "Enter a password with a minimum of 8 characters";
+    errorMessage = "Password must be 8 characters or more";
   } else if (errorType === "characters") {
     errorMessage =
       "Enter a password with at least one number and one special character";
@@ -42,9 +43,22 @@ function showError(errorType) {
     return;
   }
 
-  errorTextSection.outerHTML = `<p id="password-error" class="govuk-error-message" data-cy="password-error">
+  errorTextSection.innerHTML = `<p id="password-error" class="govuk-error-message" data-cy="password-error">
     <span class="govuk-visually-hidden">Error:</span> ${errorMessage}
     </p>`;
+
+  errorSummarySection.innerHTML = `<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary" data-cy="password-error-summary">
+  <h2 class="govuk-error-summary__title" id="error-summary-title">
+    There is a problem
+  </h2>
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+      <li>
+        <a href="#password">${errorMessage}</a>
+      </li>
+    </ul>
+  </div>
+</div>`;
 }
 
 function checkPassword(event) {
@@ -56,6 +70,6 @@ function checkPassword(event) {
   } else if (passwordInput.value !== confirmPasswordInput.value) {
     showError("unmatched");
   } else {
-    location.href = "#";
+    location.href = "/document-list";
   }
 }

--- a/public/javascripts/create-password.js
+++ b/public/javascripts/create-password.js
@@ -30,7 +30,7 @@ let passwordRegex = /^(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]/;
 function checkPassword(event) {
   event.preventDefault();
   let passwordInput = document.querySelector("#password");
-  // let confirmPasswordInput = document.querySelector("#confirm-password");
+  let confirmPasswordInput = document.querySelector("#confirm-password");
   console.log(passwordInput.value.length);
   if (passwordInput.value.length < passwordMinimumLength) {
     passwordFields.innerHTML = `<div id="password-fields">
@@ -85,6 +85,43 @@ function checkPassword(event) {
           <p id="event-name-error" class="govuk-error-message" data-cy="event-name-error">
             <span class="govuk-visually-hidden" >Error:</span> Enter a password with
             at least one number and one special character
+          </p>
+          <input
+            class="govuk-input govuk-input--width-20 govuk-input--error"
+            id="event-name"
+            name="event-name"
+            type="text"
+            data-cy="length-error-password-input"
+            aria-describedby="event-name-hint event-name-error"
+          />
+          <br />
+          <br />
+          <label class="govuk-label" for="confirm-password">
+            Confirm password
+          </label>
+          <input
+            class="govuk-input govuk-input--width-20"
+            id="confirm-password"
+            name="confirm-password"
+            type="text"
+            data-cy="length-error-confirm-password-input"
+          />
+        </div>
+      </div>`;
+  } else if (passwordInput.value !== confirmPasswordInput.value) {
+    passwordFields.innerHTML = `<div id="password-fields">
+        <div class="govuk-form-group govuk-form-group--error">
+          <h1 class="govuk-label-wrapper">
+            <label class="govuk-label govuk-label--l" for="event-name">
+              Create a password for your account
+            </label>
+          </h1>
+          <div id="event-name-hint" class="govuk-hint">
+            Password must contain 8 digits, at least one number and one special
+            character
+          </div>
+          <p id="event-name-error" class="govuk-error-message" data-cy="event-name-error">
+            <span class="govuk-visually-hidden" >Error:</span> Both passwords should match
           </p>
           <input
             class="govuk-input govuk-input--width-20 govuk-input--error"

--- a/public/javascripts/create-password.js
+++ b/public/javascripts/create-password.js
@@ -1,149 +1,61 @@
 const continueEvent = document.querySelector("#continue-button");
 const passwordFields = document.querySelector("#password-fields");
-// const lengthErrorPasswordFields = document.querySelector(
-//   "#length-error-password-fields"
-// );
+const formGroup = document.querySelector(".govuk-form-group");
+const passwordInput = document.querySelector("#password");
+const confirmPasswordInput = document.querySelector("#confirm-password");
+const errorTextSection = document.querySelector("#error");
 
 continueEvent.addEventListener("click", checkPassword);
 
 let passwordMinimumLength = 8;
 let passwordRegex = /^(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]/;
 
-// console.log(passwordInput);
+function addErrorClasses(formGroup, passwordInput, confirmPasswordInput) {
+  formGroup.classList.add("govuk-form-group--error");
+  passwordInput.classList.add("govuk-input--error");
+  confirmPasswordInput.classList.add("govuk-input--error");
+}
 
-// function showPasswordLengthError(password) {
-//   if (password.length < passwordMinimumLength) {
-//     console.log("nope");
-//   } else {
-//     console.log("ok");
-//   }
-// }
+function addAriaAttribute(passwordInput, confirmPasswordInput) {
+  passwordInput.setAttribute(
+    "aria-describedby",
+    "password-hint password-error"
+  );
+  confirmPasswordInput.setAttribute(
+    "aria-describedby",
+    "password-hint password-error"
+  );
+}
 
-// function removeClass(classToHide) {
-//   classToHide.classList.remove("no-display");
-// }
+function showError(errorType) {
+  addErrorClasses(formGroup, passwordInput, confirmPasswordInput);
+  addAriaAttribute(passwordInput, confirmPasswordInput);
 
-// function addClass(classToAdd) {
-//   classToAdd.classList.add("no-display");
-// }
+  if (errorType === "length") {
+    errorMessage = "Enter a password with a minimum of 8 characters";
+  } else if (errorType === "characters") {
+    errorMessage =
+      "Enter a password with at least one number and one special character";
+  } else if (errorType === "unmatched") {
+    errorMessage = "Both passwords should match";
+  } else {
+    return;
+  }
+
+  errorTextSection.outerHTML = `<p id="password-error" class="govuk-error-message" data-cy="password-error">
+    <span class="govuk-visually-hidden">Error:</span> ${errorMessage}
+    </p>`;
+}
 
 function checkPassword(event) {
   event.preventDefault();
-  let passwordInput = document.querySelector("#password");
-  let confirmPasswordInput = document.querySelector("#confirm-password");
-  console.log(passwordInput.value.length);
   if (passwordInput.value.length < passwordMinimumLength) {
-    passwordFields.innerHTML = `<div id="password-fields">
-        <div class="govuk-form-group govuk-form-group--error">
-          <h1 class="govuk-label-wrapper">
-            <label class="govuk-label govuk-label--l" for="event-name">
-              Create a password for your account
-            </label>
-          </h1>
-          <div id="event-name-hint" class="govuk-hint">
-            Password must contain 8 digits, at least one number and one special
-            character
-          </div>
-          <p id="event-name-error" class="govuk-error-message" data-cy="event-name-error">
-            <span class="govuk-visually-hidden" >Error:</span> Enter a password
-            with a minimum of 8 characters
-          </p>
-          <input
-            class="govuk-input govuk-input--width-20 govuk-input--error"
-            id="event-name"
-            name="event-name"
-            type="text"
-            data-cy="length-error-password-input"
-            aria-describedby="event-name-hint event-name-error"
-          />
-          <br />
-          <br />
-          <label class="govuk-label" for="confirm-password">
-            Confirm password
-          </label>
-          <input
-            class="govuk-input govuk-input--width-20"
-            id="confirm-password"
-            name="confirm-password"
-            type="text"
-            data-cy="length-error-confirm-password-input"
-          />
-        </div>
-      </div>`;
+    showError("length");
   } else if (!passwordInput.value.match(passwordRegex)) {
-    passwordFields.innerHTML = `<div id="password-fields">
-        <div class="govuk-form-group govuk-form-group--error">
-          <h1 class="govuk-label-wrapper">
-            <label class="govuk-label govuk-label--l" for="event-name">
-              Create a password for your account
-            </label>
-          </h1>
-          <div id="event-name-hint" class="govuk-hint">
-            Password must contain 8 digits, at least one number and one special
-            character
-          </div>
-          <p id="event-name-error" class="govuk-error-message" data-cy="event-name-error">
-            <span class="govuk-visually-hidden" >Error:</span> Enter a password with
-            at least one number and one special character
-          </p>
-          <input
-            class="govuk-input govuk-input--width-20 govuk-input--error"
-            id="event-name"
-            name="event-name"
-            type="text"
-            data-cy="length-error-password-input"
-            aria-describedby="event-name-hint event-name-error"
-          />
-          <br />
-          <br />
-          <label class="govuk-label" for="confirm-password">
-            Confirm password
-          </label>
-          <input
-            class="govuk-input govuk-input--width-20"
-            id="confirm-password"
-            name="confirm-password"
-            type="text"
-            data-cy="length-error-confirm-password-input"
-          />
-        </div>
-      </div>`;
+    showError("characters");
   } else if (passwordInput.value !== confirmPasswordInput.value) {
-    passwordFields.innerHTML = `<div id="password-fields">
-        <div class="govuk-form-group govuk-form-group--error">
-          <h1 class="govuk-label-wrapper">
-            <label class="govuk-label govuk-label--l" for="event-name">
-              Create a password for your account
-            </label>
-          </h1>
-          <div id="event-name-hint" class="govuk-hint">
-            Password must contain 8 digits, at least one number and one special
-            character
-          </div>
-          <p id="event-name-error" class="govuk-error-message" data-cy="event-name-error">
-            <span class="govuk-visually-hidden" >Error:</span> Both passwords should match
-          </p>
-          <input
-            class="govuk-input govuk-input--width-20 govuk-input--error"
-            id="event-name"
-            name="event-name"
-            type="text"
-            data-cy="length-error-password-input"
-            aria-describedby="event-name-hint event-name-error"
-          />
-          <br />
-          <br />
-          <label class="govuk-label" for="confirm-password">
-            Confirm password
-          </label>
-          <input
-            class="govuk-input govuk-input--width-20"
-            id="confirm-password"
-            name="confirm-password"
-            type="text"
-            data-cy="length-error-confirm-password-input"
-          />
-        </div>
-      </div>`;
+    showError("unmatched");
+  } else {
+    location.href = "#";
   }
 }

--- a/public/javascripts/create-password.js
+++ b/public/javascripts/create-password.js
@@ -1,18 +1,21 @@
-const continueEvent = document.querySelector("#continue-button");
+const continueButtonClick = document.querySelector("#continue-button");
 const passwordFields = document.querySelector("#password-fields");
-const formGroup = document.querySelector(".govuk-form-group");
-const passwordInput = document.querySelector("#password");
-const confirmPasswordInput = document.querySelector("#confirm-password");
-const errorTextSection = document.querySelector("#error");
-const errorSummarySection = document.querySelector("#error-summary");
-
-continueEvent.addEventListener("click", checkPassword);
+const passwordFormGroup = document.querySelector(".password-form-group");
+const confirmPasswordFormGroup = document.querySelector(
+  ".confirm-password-form-group"
+);
 
 let passwordMinimumLength = 8;
 let passwordRegex = /^(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]/;
 
-function addErrorClasses(formGroup, passwordInput, confirmPasswordInput) {
-  formGroup.classList.add("govuk-form-group--error");
+function addErrorClasses(
+  passwordFormGroup,
+  confirmPasswordFormGroup,
+  passwordInput,
+  confirmPasswordInput
+) {
+  passwordFormGroup.classList.add("govuk-form-group--error");
+  confirmPasswordFormGroup.classList.add("govuk-form-group--error");
   passwordInput.classList.add("govuk-input--error");
   confirmPasswordInput.classList.add("govuk-input--error");
 }
@@ -28,8 +31,16 @@ function addAriaAttribute(passwordInput, confirmPasswordInput) {
   );
 }
 
+const errorTextSection = document.querySelector("#error");
+const errorSummarySection = document.querySelector("#error-summary");
+
 function showError(errorType) {
-  addErrorClasses(formGroup, passwordInput, confirmPasswordInput);
+  addErrorClasses(
+    passwordFormGroup,
+    confirmPasswordFormGroup,
+    passwordInput,
+    confirmPasswordInput
+  );
   addAriaAttribute(passwordInput, confirmPasswordInput);
 
   if (errorType === "length") {
@@ -61,6 +72,9 @@ function showError(errorType) {
 </div>`;
 }
 
+const passwordInput = document.querySelector("#password");
+const confirmPasswordInput = document.querySelector("#confirm-password");
+
 function checkPassword(event) {
   event.preventDefault();
   if (passwordInput.value.length < passwordMinimumLength) {
@@ -73,3 +87,13 @@ function checkPassword(event) {
     location.href = "/document-list";
   }
 }
+
+function checkEnterKeyPressed(event) {
+  if (event.key === "Enter") {
+    checkPassword(event);
+  }
+}
+
+continueButtonClick.addEventListener("click", checkPassword);
+passwordInput.addEventListener("keypress", checkEnterKeyPressed);
+confirmPasswordInput.addEventListener("keypress", checkEnterKeyPressed);


### PR DESCRIPTION
- Password is hidden
- Added error text and summary for if the password is too short, doesn't meet character requirements or doesn't match
- Can submit by clicking the button or pressing the enter key on keyboard

Still to do:
- Add correct links for back button and continue (change tests accordingly)

Initial page
<img width="1496" alt="Create password - initial" src="https://user-images.githubusercontent.com/17614754/183890082-780b657a-4517-46a6-bd78-215768609629.png">

When the password is too short
<img width="1492" alt="Create password - length error" src="https://user-images.githubusercontent.com/17614754/183890093-6c2cae1b-4e9e-4aba-b0c9-27c6f2b3650e.png">

When the password doesn't meet character type requirements
<img width="1488" alt="Create password - character type error" src="https://user-images.githubusercontent.com/17614754/183890097-2d0644cb-1735-4f67-a62b-0ce9b456ebfd.png">

When the passwords don't match
<img width="1495" alt="Create password - match error" src="https://user-images.githubusercontent.com/17614754/183890073-9934e3c5-d197-4dc6-b0ca-c6548d663aa9.png">
