### PR TITLE
Create 'Upload choice' page

### DIFF
--- a/cypress/e2e/upload-choice/upload-choice-spec.cy.js
+++ b/cypress/e2e/upload-choice/upload-choice-spec.cy.js
@@ -1,0 +1,93 @@
+describe("name page", () => {
+  beforeEach(() => {
+    cy.visit("/upload-choice");
+  });
+
+  context("back link", () => {
+    beforeEach(() => {
+      cy.get('[data-testid="choice-back-link"]').as("button");
+    });
+
+    it("displays", () => {
+      cy.get("@button").should("be.visible");
+    });
+
+    it("says 'Back'", () => {
+      cy.contains("Back");
+    });
+
+    it("links to the right page", () => {
+      cy.get("@button").click();
+      cy.url().should("eq", "http://localhost:3000/upload-choice/#");
+    });
+  });
+
+  context("titles", () => {
+    beforeEach(() => {
+      cy.get('[data-testid="choice-title"]').as("title");
+      cy.get('[data-testid="choice-subtitle"]').as("subtitle");
+    });
+
+    it("displays", () => {
+      cy.get("@title").should("be.visible");
+      cy.get("@subtitle").should("be.visible");
+    });
+
+    it("has a title that says 'Upload'", () => {
+      cy.get("@title").contains("Upload");
+    });
+
+    it("has a subtitle that says 'Do you want to upload a'", () => {
+      cy.get("@subtitle").contains("Do you want to upload a");
+    });
+  });
+
+  context("radios", () => {
+    beforeEach(() => {
+      cy.get("[data-testid=birth-certificate").as("birth");
+      cy.get("[data-testid=marriage-civil-certificate").as("marriage-civil");
+    });
+
+    it("displays", () => {
+      cy.get("@birth").should("be.visible");
+      cy.get("@marriage-civil").should("be.visible");
+    });
+
+    it("has an option saying 'Birth certificate'", () => {
+      cy.get("@birth").contains("Birth certificate");
+    });
+
+    it("has an option saying 'Marriage/ civil partnership certificate'", () => {
+      cy.get("@marriage-civil").contains(
+        "Marriage/ civil partnership certificate"
+      );
+    });
+  });
+
+  context("continue button", () => {
+    beforeEach(() => {
+      cy.get('[data-testid="continue-button"]').as("button");
+    });
+
+    it("displays", () => {
+      cy.get("@button").should("be.visible");
+    });
+
+    it("says 'Continue'", () => {
+      cy.contains("Continue");
+    });
+
+    it("has a green background", () => {
+      cy.get("@button").should(
+        "have.css",
+        "background-color",
+        "rgb(0, 112, 60)"
+      );
+    });
+
+    it("links to the right page", () => {
+      cy.get("@button").click();
+      cy.url().should("eq", "http://localhost:3000/upload-choice/#");
+    });
+  });
+});

--- a/public/upload-choice/index.html
+++ b/public/upload-choice/index.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+  <head>
+    <meta charset="utf-8" />
+    <title>
+      GOV.UK - The best place to find government services and information
+    </title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <meta name="theme-color" content="#0b0c0c" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <link
+      rel="shortcut icon"
+      sizes="16x16 32x32 48x48"
+      href="/assets/images/favicon.ico"
+      type="image/x-icon"
+    />
+    <link
+      rel="mask-icon"
+      href="/assets/images/govuk-mask-icon.svg"
+      color="#0b0c0c"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/assets/images/govuk-apple-touch-icon-180x180.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="167x167"
+      href="/assets/images/govuk-apple-touch-icon-167x167.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="152x152"
+      href="/assets/images/govuk-apple-touch-icon-152x152.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      href="/assets/images/govuk-apple-touch-icon.png"
+    />
+    <!--[if !IE 8]><!-->
+    <link href="/govuk-frontend/govuk/all.css" rel="stylesheet" />
+    <!--<![endif]-->
+    <link href="/stylesheet/styles.css" rel="stylesheet" />
+    <!--[if IE 8]>
+      <link href="/govuk-frontend/all-ie8.css" rel="stylesheet" />
+    <![endif]-->
+    <!--[if lt IE 9]>
+      <script src="/html5-shiv/html5shiv.js"></script>
+    <![endif]-->
+    <meta
+      property="og:image"
+      content="/assets/images/govuk-opengraph-image.png"
+    />
+  </head>
+
+  <body class="govuk-template__body">
+    <script>
+      document.body.className = document.body.className
+        ? document.body.className + " js-enabled"
+        : "js-enabled";
+    </script>
+    <a
+      href="#main-content"
+      class="govuk-skip-link"
+      data-module="govuk-skip-link"
+    >
+      Skip to main content
+    </a>
+    <header class="govuk-header" role="banner" data-module="govuk-header">
+      <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo">
+          <a href="/" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <!--[if gt IE 8]><!-->
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                class="govuk-header__logotype-crown"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 132 97"
+                height="30"
+                width="36"
+              >
+                <path
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+                ></path>
+              </svg>
+              <!--<![endif]-->
+              <!--[if IE 8]>
+                <img
+                  src="/assets/images/govuk-logotype-crown.png"
+                  class="govuk-header__logotype-crown-fallback-image"
+                  width="36"
+                  height="32"
+                />
+              <![endif]-->
+              <span class="govuk-header__logotype-text"> GOV.UK </span>
+            </span>
+          </a>
+        </div>
+      </div>
+    </header>
+
+    <div class="govuk-width-container">
+      <a href="#" class="govuk-back-link" data-testid="choice-back-link"
+        >Back</a
+      >
+      <main class="govuk-main-wrapper" id="main-content" role="main">
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading" data-testid="choice-title">
+                Upload
+              </h1>
+            </legend>
+            <h2 class="govuk-heading-m" data-testid="choice-subtitle">
+              Do you want to upload a
+            </h2>
+            <div class="govuk-radios" data-module="govuk-radios">
+              <div class="govuk-radios__item" data-testid="birth-certificate">
+                <input
+                  class="govuk-radios__input"
+                  id="upload"
+                  name="upload"
+                  type="radio"
+                  value="birth-certificate"
+                />
+                <label class="govuk-label govuk-radios__label" for="upload">
+                  Birth certificate
+                </label>
+              </div>
+              <div
+                class="govuk-radios__item"
+                data-testid="marriage-civil-certificate"
+              >
+                <input
+                  class="govuk-radios__input"
+                  id="upload-2"
+                  name="upload"
+                  type="radio"
+                  value="marriage-civil-certificate"
+                />
+                <label class="govuk-label govuk-radios__label" for="upload-2">
+                  Marriage/ civil partnership certificate
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <button
+          class="govuk-button"
+          data-module="govuk-button"
+          data-testid="continue-button"
+          onclick="location.href='#'"
+        >
+          Continue
+        </button>
+      </main>
+    </div>
+
+    <footer class="govuk-footer" role="contentinfo">
+      <div class="govuk-width-container">
+        <div class="govuk-footer__meta">
+          <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              class="govuk-footer__licence-logo"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 483.2 195.7"
+              height="17"
+              width="41"
+            >
+              <path
+                fill="currentColor"
+                d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+              />
+            </svg>
+            <span class="govuk-footer__licence-description">
+              All content is available under the
+              <a
+                class="govuk-footer__link"
+                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                rel="license"
+                >Open Government Licence v3.0</a
+              >, except where otherwise stated
+            </span>
+          </div>
+          <div class="govuk-footer__meta-item">
+            <a
+              class="govuk-footer__link govuk-footer__copyright-logo"
+              href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+              >© Crown copyright</a
+            >
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script src="/javascripts/gov.js"></script>
+    <script>
+      window.GOVUKFrontend.initAll();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Summary: This is the page where users specify which document they want to
upload. It consists of a title, subtitle and a couple of radios as per
the design and has tests to check if the content is correct.

Tasks: Update the links for the back and continue buttons, so they link
to the right pages.

Looks like:
<img width="991" alt="Screenshot 2022-08-15 at 11 55 51" src="https://user-images.githubusercontent.com/64155953/184624264-1a25084c-a799-4599-b1b7-005ff899b1bf.png">
